### PR TITLE
Update to 1.1.0 (Wait Time Patch)

### DIFF
--- a/src/mainHack.ns
+++ b/src/mainHack.ns
@@ -176,9 +176,9 @@ export async function main(ns) {
 
     const targetServers = findTargetServer(ns, hackableServers, serverMap.servers, serverExtraData)
     const bestTarget = targetServers.shift()
-    const hackTime = ns.getHackTime(bestTarget) * 1000
-    const growTime = ns.getGrowTime(bestTarget) * 1000
-    const weakenTime = ns.getWeakenTime(bestTarget) * 1000
+    const hackTime = ns.getHackTime(bestTarget)
+    const growTime = ns.getGrowTime(bestTarget)
+    const weakenTime = ns.getWeakenTime(bestTarget)
 
     const growDelay = Math.max(0, weakenTime - growTime - 15 * 1000)
     const hackDelay = Math.max(0, growTime + growDelay - hackTime - 15 * 1000)


### PR DESCRIPTION
In version 1.1.0 the three "getXTime" functions have been changed to output milliseconds instead of seconds, making the "* 1000" obsolete and in fact, causes the sleep times to grow to obscene levels.

Patch has been tested and is working in the following game versions: 

- v1.1.0
- v1.2.0