### PR TITLE
Fix for timers

### DIFF
--- a/src/mainHack.ns
+++ b/src/mainHack.ns
@@ -176,9 +176,9 @@ export async function main(ns) {
 
     const targetServers = findTargetServer(ns, hackableServers, serverMap.servers, serverExtraData)
     const bestTarget = targetServers.shift()
-    const hackTime = ns.getHackTime(bestTarget) * 1000
-    const growTime = ns.getGrowTime(bestTarget) * 1000
-    const weakenTime = ns.getWeakenTime(bestTarget) * 1000
+    const hackTime = ns.getHackTime(bestTarget)
+    const growTime = ns.getGrowTime(bestTarget)
+    const weakenTime = ns.getWeakenTime(bestTarget)
 
     const growDelay = Math.max(0, weakenTime - growTime - 15 * 1000)
     const hackDelay = Math.max(0, growTime + growDelay - hackTime - 15 * 1000)


### PR DESCRIPTION
The * 1000 multiplication for hackTime, growTime, and weakenTime broke the functionality. My guess is that in a game update the return from the ns getter methods changed from milliseconds to seconds, so the muliplication with 1000 is no longer necessary.